### PR TITLE
Add `match` option

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import type { FileSelectorConfig, FileSelectorTheme } from './types.js'
 import {
   CURSOR_HIDE,
   ensureTrailingSlash,
+  extensionCheck,
   getDirItems,
   getMaxLength,
   isEscapeKey
@@ -46,7 +47,6 @@ const fileSelectorTheme: FileSelectorTheme = {
 export default createPrompt<string, FileSelectorConfig>((config, done) => {
   const {
     pageSize = 10,
-    extensions = [],
     hideNonMatch = false,
     disabledLabel = ' (not allowed)',
     noFilesFound = 'No files found'
@@ -64,9 +64,7 @@ export default createPrompt<string, FileSelectorConfig>((config, done) => {
 
     for (const item of _items) {
       item.isDisabled =
-        !item.isDir &&
-        !!extensions.length &&
-        !extensions.some(ext => item.name.endsWith(ext))
+        !item.isDir && !extensionCheck(item, config.match || config.extensions)
     }
 
     return hideNonMatch ? _items.filter(item => !item.isDisabled) : _items

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,9 +67,11 @@ export type Item = {
    */
   isDir: boolean
   /**
-   * If the item is disabled. Used when a list of extensions is provided.
+   * If the item is disabled.
+   *
+   * Used when a list of extensions is provided or when the `match` function returns `false`.
    */
-  isDisabled: boolean
+  isDisabled?: boolean
 }
 
 export type FileSelectorConfig = {
@@ -86,9 +88,15 @@ export type FileSelectorConfig = {
   pageSize?: number
   /**
    * The extensions to filter the files.
-   * @default []
+   * @deprecated Use `match` instead. Will be removed in v0.4.0.
    */
   extensions?: string[]
+  /**
+   * The function to use to filter the files. Return `true` to include the file in the list.
+   *
+   * If not provided, all files will be included.
+   */
+  match?: (file: Item) => boolean
   /**
    * If true, the list will be filtered to only show files that match the extensions.
    * @default false

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -41,6 +41,24 @@ export function getMaxLength(arr: string[]): number {
 }
 
 /**
+ * Check if the given item matches the given match function or extensions.
+ */
+export function extensionCheck(
+  item: Item,
+  match?: string[] | ((item: Item) => boolean)
+): boolean {
+  if (Array.isArray(match)) {
+    return match.some(ext => item.name.endsWith(ext))
+  }
+
+  if (typeof match === 'function') {
+    return match(item)
+  }
+
+  return true
+}
+
+/**
  * Get items of a directory
  */
 export function getDirItems(dir: string): Item[] {
@@ -49,8 +67,7 @@ export function getDirItems(dir: string): Item[] {
     .map(dirent => ({
       name: dirent.name,
       path: path.join(dirent.parentPath, dirent.name),
-      isDir: dirent.isDirectory(),
-      isDisabled: false
+      isDir: dirent.isDirectory()
     }))
     .sort((a, b) => {
       if (a.isDir && !b.isDir) {


### PR DESCRIPTION
Closes #1
Replaces #3 

### With `extensions` as empty array:
![image](https://github.com/user-attachments/assets/c4835512-5b5b-49d9-ba87-1bb760b91cd3)

### With `match` as:

```js
match: file => file.name.endsWith('.json')
```

![image](https://github.com/user-attachments/assets/991c477c-8cc8-4700-b02c-657b36121ce7)

### With `extensions` as empty array and `match` as:

```js
match: file => file.name.endsWith('.json')
```

![image](https://github.com/user-attachments/assets/991c477c-8cc8-4700-b02c-657b36121ce7)

The value of `extensions` is used only if `match` is not defined.

As expected, if neither option is present, no file will be disabled.