### PR TITLE
Cancel selection when press `Esc`

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ const filePath = await fileSelector({
 | match | `(file: Item) => boolean` | | A function to filter the files.<br/> If not provided, all files will be included. |
 | hideNonMatch | `boolean` | | If true, the list will be filtered to only show files that match the extensions.<br/> **Default**: `false` |
 | disabledLabel | `string` | | The label to display when a file is disabled.<br/> **Default**: ` (not allowed)` |
+| allowCancel | `boolean` | | If true, the prompt will allow the user to cancel the selection.<br/> **Default**: `false` |
+| canceledLabel | `string` | | The label to display when the prompt is canceled.<br/> **Default**: `Canceled` |
 | noFilesFound | `string` | | The message to display when no files are found.<br/> **Default**: `No files found` |
 | theme | [See Theming](#theming) | | The theme to use for the file selector. |
 | ~~extensions~~ | ~~`string[]`~~ | | ~~The extensions to filter the files.~~<br/>(Deprecated in favor of `match` option) |

--- a/src/types.ts
+++ b/src/types.ts
@@ -108,6 +108,16 @@ export type FileSelectorConfig = {
    */
   disabledLabel?: string
   /**
+   * If true, the prompt will allow the user to cancel the selection.
+   * @default false
+   */
+  allowCancel?: boolean
+  /**
+   * The label to display when the user cancels the selection.
+   * @default 'Canceled'
+   */
+  canceledLabel?: string
+  /**
    * The message to display when no files are found.
    * @default 'No files found'
    */


### PR DESCRIPTION
Closes #2

#### Add `allowCancel` option:
| enabled | disabled (default) |
| - | - |
| ![Animation](https://github.com/user-attachments/assets/21c65170-fe51-4c1f-8f40-4d5c8065fad2) | ![image](https://github.com/user-attachments/assets/fd9e20b8-a533-4586-9215-6e0891a14cee) |

#### Changed the key to go to the home directory from `Esc` to `Backspace`, now `Esc` is reserved to cancel the selection when `allowCancel` is `true`.
