### PR TITLE
Compact help tip

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -165,24 +165,9 @@ export default createPrompt<string, FileSelectorConfig>((config, done) => {
   const header = theme.style.currentDir(ensureTrailingSlash(currentDir))
   const helpTip = useMemo(() => {
     const helpTipLines = [
-      theme.style.help(
-        `Use ${theme.style.key(figures.arrowUp + figures.arrowDown)} to navigate through the list`
-      ),
-      theme.style.help(
-        `Press ${theme.style.key('<backspace>')} to navigate to the parent directory`
-      ),
-      theme.style.help(
-        `Press ${theme.style.key('<enter>')} to select a file or navigate to a directory`
-      )
+      `${theme.style.key(figures.arrowUp + figures.arrowDown)} navigate, ${theme.style.key('<enter>')} select or open directory`,
+      `${theme.style.key('<backspace>')} go back${allowCancel ? `, ${theme.style.key('<esc>')} cancel` : ''}`
     ]
-
-    if (allowCancel) {
-      helpTipLines.push(
-        theme.style.help(
-          `Press ${theme.style.key('<esc>')} to cancel the selection`
-        )
-      )
-    }
 
     const helpTipMaxLength = getMaxLength(helpTipLines)
     const delimiter = figures.lineBold.repeat(helpTipMaxLength)


### PR DESCRIPTION
This is a small change to make the help tip a little more compact, the idea is that it takes up less space on the screen.
Both samples were taken having `allowCancel` as `true`.

| Current | With this change |
| - | - |
| ![image](https://github.com/user-attachments/assets/f585e9c8-374a-484f-84d1-f1b5376daf9b) | ![image](https://github.com/user-attachments/assets/13752241-6b63-4a78-afaa-dfbdde12ef6d) |
