### PR TITLE
Replace `noFilesFound` and `canceledLabel` options

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,11 @@ const filePath = await fileSelector({
 | `hideNonMatch` | `boolean` | | If true, the list will be filtered to show only files that match the `match` function.<br/> **Default**: `false` |
 | `disabledLabel` | `string` | | The label to display when a file is disabled.<br/> **Default**: ` (not allowed)` |
 | `allowCancel` | `boolean` | | If true, the prompt will allow the user to cancel the selection.<br/> **Default**: `false` |
-| `canceledLabel` | `string` | | The label to display when the prompt is canceled.<br/> **Default**: `Canceled` |
-| `noFilesFound` | `string` | | The message to display when no files are found.<br/> **Default**: `No files found` |
+| `cancelText` | `string` | | The message to display when the user cancels the selection.<br/> **Default**: `Canceled.` |
+| `emptyText` | `string` | | The message that will be displayed when the directory is empty.<br/> **Default**: `Directory is empty.` |
 | `theme` | [See Theming](#theming) | | The theme to use for the file selector. |
+| ~~`canceledLabel`~~ | ~~`string`~~ | | **Deprecated**: Use `cancelText` instead. Will be removed in the next major version. |
+| ~~`noFilesFound`~~ | ~~`string`~~ | | **Deprecated**: Use `emptyText` instead. Will be removed in the next major version. |
 
 ## Theming
 
@@ -75,10 +77,20 @@ type FileSelectorTheme = {
      */
     active: (text: string) => string
     /**
-     * The style to use for the no files found message.
+     * The style to use for the cancel text.
      * @default chalk.red
      */
-    noFilesFound: (text: string) => string
+    cancelText: (text: string) => string
+    /**
+     * Alias for `emptyText`.
+     * @deprecated Use `emptyText` instead. Will be removed in the next major version.
+     */
+    noFilesFound?: (text: string) => string
+    /**
+     * The style to use for the empty text.
+     * @default chalk.red
+     */
+    emptyText: (text: string) => string
     /**
      * The style to use for items of type directory.
      * @default chalk.yellow

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,7 @@ const fileSelectorTheme: FileSelectorTheme = {
   style: {
     disabled: (text: string) => chalk.dim(text),
     active: (text: string) => chalk.cyan(text),
+    cancelText: (text: string) => chalk.red(text),
     emptyText: (text: string) => chalk.red(text),
     directory: (text: string) => chalk.yellow(text),
     file: (text: string) => chalk.white(text),
@@ -154,7 +155,7 @@ export default createPrompt<string, FileSelectorConfig>((config, done) => {
   const message = theme.style.message(config.message)
 
   if (status === 'canceled') {
-    return `${prefix} ${message} ${theme.style.error(cancelText)}`
+    return `${prefix} ${message} ${theme.style.cancelText(cancelText)}`
   }
 
   if (status === 'done') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,9 +51,9 @@ export default createPrompt<string, FileSelectorConfig>((config, done) => {
     pageSize = 10,
     hideNonMatch = false,
     disabledLabel = ' (not allowed)',
-    allowCancel = false,
-    canceledLabel = 'Canceled'
+    allowCancel = false
   } = config
+  const cancelText = config.cancelText || config.canceledLabel || 'Canceled.'
   const emptyText =
     config.emptyText || config.noFilesFound || 'Directory is empty.'
 
@@ -154,7 +154,7 @@ export default createPrompt<string, FileSelectorConfig>((config, done) => {
   const message = theme.style.message(config.message)
 
   if (status === 'canceled') {
-    return `${prefix} ${message} ${theme.style.error(canceledLabel)}`
+    return `${prefix} ${message} ${theme.style.error(cancelText)}`
   }
 
   if (status === 'done') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,9 +52,11 @@ export default createPrompt<string, FileSelectorConfig>((config, done) => {
     hideNonMatch = false,
     disabledLabel = ' (not allowed)',
     allowCancel = false,
-    canceledLabel = 'Canceled',
-    noFilesFound = 'No files found'
+    canceledLabel = 'Canceled'
   } = config
+  const emptyText =
+    config.emptyText || config.noFilesFound || 'Directory is empty.'
+
   const [status, setStatus] = useState('pending')
   const theme = makeTheme<FileSelectorTheme>(fileSelectorTheme, config.theme)
   const prefix = usePrefix({ theme })
@@ -183,5 +185,5 @@ export default createPrompt<string, FileSelectorConfig>((config, done) => {
     return `${delimiter}\n${helpTipLines.join('\n')}`
   }, [])
 
-  return `${prefix} ${message}\n${header}\n${!page.length ? theme.style.noFilesFound(noFilesFound) : page}\n${helpTip}${CURSOR_HIDE}`
+  return `${prefix} ${message}\n${header}\n${!page.length ? theme.style.noFilesFound(emptyText) : page}\n${helpTip}${CURSOR_HIDE}`
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,7 @@ const fileSelectorTheme: FileSelectorTheme = {
   style: {
     disabled: (text: string) => chalk.dim(text),
     active: (text: string) => chalk.cyan(text),
-    noFilesFound: (text: string) => chalk.red(text),
+    emptyText: (text: string) => chalk.red(text),
     directory: (text: string) => chalk.yellow(text),
     file: (text: string) => chalk.white(text),
     currentDir: (text: string) => chalk.magenta(text),
@@ -56,6 +56,10 @@ export default createPrompt<string, FileSelectorConfig>((config, done) => {
   } = config
   const emptyText =
     config.emptyText || config.noFilesFound || 'Directory is empty.'
+
+  if (config.theme?.style?.noFilesFound) {
+    config.theme.style.emptyText ??= config.theme.style.noFilesFound
+  }
 
   const [status, setStatus] = useState('pending')
   const theme = makeTheme<FileSelectorTheme>(fileSelectorTheme, config.theme)
@@ -185,5 +189,5 @@ export default createPrompt<string, FileSelectorConfig>((config, done) => {
     return `${delimiter}\n${helpTipLines.join('\n')}`
   }, [])
 
-  return `${prefix} ${message}\n${header}\n${!page.length ? theme.style.noFilesFound(emptyText) : page}\n${helpTip}${CURSOR_HIDE}`
+  return `${prefix} ${message}\n${header}\n${!page.length ? theme.style.emptyText(emptyText) : page}\n${helpTip}${CURSOR_HIDE}`
 })

--- a/src/types.ts
+++ b/src/types.ts
@@ -113,10 +113,15 @@ export type FileSelectorConfig = {
    */
   allowCancel?: boolean
   /**
-   * The label to display when the user cancels the selection.
-   * @default 'Canceled'
+   * Alias for `cancelText`.
+   * @deprecated Use `cancelText` instead. Will be removed in the next major version.
    */
   canceledLabel?: string
+  /**
+   * The message to display when the user cancels the selection.
+   * @default 'Canceled.'
+   */
+  cancelText?: string
   /**
    * Alias for `emptyText`.
    * @deprecated Use `emptyText` instead. Will be removed in the next major version.

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,10 +21,15 @@ export type FileSelectorTheme = {
      */
     active: (text: string) => string
     /**
-     * The style to use for the no files found message.
+     * Alias for `emptyText`.
+     * @deprecated Use `emptyText` instead. Will be removed in the next major version.
+     */
+    noFilesFound?: (text: string) => string
+    /**
+     * The style to use for the empty text.
      * @default chalk.red
      */
-    noFilesFound: (text: string) => string
+    emptyText: (text: string) => string
     /**
      * The style to use for items of type directory.
      * @default chalk.yellow

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,11 @@ export type FileSelectorTheme = {
      */
     active: (text: string) => string
     /**
+     * The style to use for the cancel text.
+     * @default chalk.red
+     */
+    cancelText: (text: string) => string
+    /**
      * Alias for `emptyText`.
      * @deprecated Use `emptyText` instead. Will be removed in the next major version.
      */

--- a/src/types.ts
+++ b/src/types.ts
@@ -113,10 +113,15 @@ export type FileSelectorConfig = {
    */
   canceledLabel?: string
   /**
-   * The message to display when no files are found.
-   * @default 'No files found'
+   * Alias for `emptyText`.
+   * @deprecated Use `emptyText` instead. Will be removed in the next major version.
    */
   noFilesFound?: string
+  /**
+   * The message that will be displayed when the directory is empty.
+   * @default 'Directory is empty.'
+   */
+  emptyText?: string
   /**
    * The theme to use for the file selector.
    */


### PR DESCRIPTION
### Deprecate:
* Option `noFilesFound` and `canceledLabel` to be removed entirely in the next major version.
* Theme style `noFilesFound` to be removed entirely in the next major version.

### New Options:
* `emptyText` to replace `noFilesFound` option.
* `cancelText` to replace `canceledLabel` option.

### New Theme Styles:
* `emptyText` to replace `noFilesFound` style.
* `cancelText` to `cancelText` option.