### PR TITLE
Replace `dirent.parentPath` with `dir` path

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -56,7 +56,7 @@ export function matchCheck(
 export function getDirItems(dir: string): Item[] {
   return fs.readdirSync(dir, { withFileTypes: true }).map(dirent => ({
     name: dirent.name,
-    path: path.join(dirent.parentPath, dirent.name),
+    path: path.join(dir, dirent.name),
     isDir: dirent.isDirectory()
   }))
 }


### PR DESCRIPTION
Closes #14 

In node versions >= 18 and < 18.20.0, `dirent.parentPath` does not exist, to fix this it is simply replaced by `dir` path, already present in `getDirItems` as parameter.

| Before | After |
| - | - |
| ![image](https://github.com/user-attachments/assets/6b008aea-fe85-4e99-99c2-958f0d4ff1bf) | ![image](https://github.com/user-attachments/assets/da2bcea1-2bbe-4a55-93e0-7140a2b25e82) |