### PR TITLE
[WIP] Add `helpMode` option to theme

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -44,7 +44,8 @@ const fileSelectorTheme: FileSelectorTheme = {
     currentDir: (text: string) => chalk.magenta(text),
     help: (text: string) => chalk.white(text),
     key: (text: string) => chalk.cyan(text)
-  }
+  },
+  helpMode: 'always'
 }
 
 export default createPrompt<string, FileSelectorConfig>((config, done) => {
@@ -164,6 +165,10 @@ export default createPrompt<string, FileSelectorConfig>((config, done) => {
 
   const header = theme.style.currentDir(ensureTrailingSlash(currentDir))
   const helpTip = useMemo(() => {
+    if (theme.helpMode !== 'always') {
+      return ''
+    }
+
     const helpTipLines = [
       `${theme.style.key(figures.arrowUp + figures.arrowDown)} navigate, ${theme.style.key('<enter>')} select or open directory`,
       `${theme.style.key('<backspace>')} go back${allowCancel ? `, ${theme.style.key('<esc>')} cancel` : ''}`

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,6 +61,15 @@ export type FileSelectorTheme = {
      */
     key: (text: string) => string
   }
+  /**
+   * The help mode to use.
+   *
+   * If set to `always`, the help will always be displayed.
+   *
+   * If set to `never`, the help will not be displayed.
+   * @default 'always'
+   */
+  helpMode: 'always' | 'never'
 }
 
 export type Item = {


### PR DESCRIPTION
* `helpMode` currently has two possible values: `always` or `never`.

| 'always' | 'never' |
| - | - |
| ![image](https://github.com/user-attachments/assets/f9bc6905-53c3-4388-9aad-3230b66b2193) | ![image](https://github.com/user-attachments/assets/819637a8-98bf-4eb5-b6a6-cd5629c3e9ae) |

Honestly I'm not sure about including it in the next version, somehow it feels incomplete.