### PR TITLE
Replace `path` option with `basePath` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ const filePath = await fileSelector({
 | Option | Type | Required | Description |
 |--------|------|----------|-------------|
 | `message` | `string` | ✔ | The message to display in the prompt. |
-| `path` | `string` | | The path to the directory where it will be started.<br/> **Default**: `process.cwd()` |
+| `basePath` | `string` | | The path to the directory where it will be started.<br/> **Default**: `process.cwd()` |
 | `pageSize` | `number` | | The maximum number of items to display in the list.<br/> **Default**: `10` |
 | `match` | `(file: Item) => boolean` | | A function to filter the files.<br/> If not provided, all files will be included. |
 | `hideNonMatch` | `boolean` | | If true, the list will be filtered to show only files that match the `match` function.<br/> **Default**: `false` |
@@ -49,6 +49,7 @@ const filePath = await fileSelector({
 | `cancelText` | `string` | | The message to display when the user cancels the selection.<br/> **Default**: `Canceled.` |
 | `emptyText` | `string` | | The message that will be displayed when the directory is empty.<br/> **Default**: `Directory is empty.` |
 | `theme` | [See Theming](#theming) | | The theme to use for the file selector. |
+| ~~`path`~~ | ~~`string`~~ | | **Deprecated**: Use `basePath` instead. Will be removed in the next major version. |
 | ~~`canceledLabel`~~ | ~~`string`~~ | | **Deprecated**: Use `cancelText` instead. Will be removed in the next major version. |
 | ~~`noFilesFound`~~ | ~~`string`~~ | | **Deprecated**: Use `emptyText` instead. Will be removed in the next major version. |
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,7 +67,7 @@ export default createPrompt<string, FileSelectorConfig>((config, done) => {
   const prefix = usePrefix({ theme })
 
   const [currentDir, setCurrentDir] = useState(
-    path.resolve(process.cwd(), config.path || '.')
+    path.resolve(process.cwd(), config.basePath || config.path || '.')
   )
 
   const items = useMemo(() => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -87,10 +87,15 @@ export type Item = {
 export type FileSelectorConfig = {
   message: string
   /**
+   * Alias for `basePath`.
+   * @deprecated Use `basePath` instead. Will be removed in the next major version.
+   */
+  path?: string
+  /**
    * The path to the directory where it will be started.
    * @default process.cwd()
    */
-  path?: string
+  basePath?: string
   /**
    * The maximum number of items to display in the list.
    * @default 10


### PR DESCRIPTION
### Deprecate:

* Option `path` to be removed entirely in the next major version.

### New Option:

* `basePath` to replace `path` option.