### PR TITLE
feat: Add select directory feature as configurable

### DIFF
--- a/examples/expect.js
+++ b/examples/expect.js
@@ -1,0 +1,30 @@
+import fileSelector from '../dist/index.js'
+
+async function selectFile() {
+  await fileSelector({
+    message: 'Select a file:',
+  })
+}
+
+async function selectDirectory() {
+  await fileSelector({
+    message: 'Select a directory:',
+    // match:(item)=> {
+    //   show directories only
+    //   return item.isDir;
+    // },
+    // hideNonMatch: true,
+    expect: 'directory',
+  })
+}
+
+async function selectFileOrDirectory() {
+  await fileSelector({
+    message: 'Select a file or directory:',
+    expect: 'both',
+  })
+}
+
+// await selectFile()
+await selectDirectory()
+// await selectFileOrDirectory()

--- a/src/types.ts
+++ b/src/types.ts
@@ -84,6 +84,8 @@ export type Item = {
   isDisabled?: boolean
 }
 
+export type ExpectOption = 'file' | 'directory' | 'both';
+
 export type FileSelectorConfig = {
   message: string
   /**
@@ -122,6 +124,11 @@ export type FileSelectorConfig = {
    * @default false
    */
   allowCancel?: boolean
+  /**
+   * Configuration selection file or directory, or both
+   * @default 'file'
+   */
+  expect?: ExpectOption
   /**
    * Alias for `cancelText`.
    * @deprecated Use `cancelText` instead. Will be removed in the next major version.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 import type { KeypressEvent } from '@inquirer/core'
 
-import type { Item } from './types.js'
+import type {ExpectOption, Item} from './types.js'
 
 /**
  * ANSI escape code to hide the cursor
@@ -53,12 +53,21 @@ export function matchCheck(
 /**
  * Get items of a directory
  */
-export function getDirItems(dir: string): Item[] {
-  return fs.readdirSync(dir, { withFileTypes: true }).map(dirent => ({
-    name: dirent.name,
-    path: path.join(dir, dirent.name),
-    isDir: dirent.isDirectory()
-  }))
+export function getDirItems(dir: string, expect: ExpectOption): Item[] {
+    const dirItems = fs.readdirSync(dir, {withFileTypes: true}).map(dirent => ({
+        name: dirent.name,
+        path: path.join(dir, dirent.name),
+        isDir: dirent.isDirectory()
+    }))
+    if (['directory', 'both'].includes(expect)) {
+        const curItem = {
+            name: '.',
+            path: dir,
+            isDir: true
+        }
+        return [curItem, ...dirItems];
+    }
+    return dirItems;
 }
 
 /**


### PR DESCRIPTION
Implement the function of directory selection, added parameter `expect?: 'file' | 'directory' | 'both'` to `FileSelectorConfig`.
Fix this issue: https://github.com/br14n-sol/inquirer-file-selector/issues/18