### PR TITLE
Remove deprecated options

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ const filePath = await fileSelector({
 | `theme` | [See Theming](#theming) | | The theme to use for the file selector. |
 | ~~`path`~~ | ~~`string`~~ | | **Deprecated**: Use `basePath` instead. Will be removed in the next major version. |
 | ~~`canceledLabel`~~ | ~~`string`~~ | | **Deprecated**: Use `cancelText` instead. Will be removed in the next major version. |
-| ~~`noFilesFound`~~ | ~~`string`~~ | | **Deprecated**: Use `emptyText` instead. Will be removed in the next major version. |
 
 ## Theming
 
@@ -82,11 +81,6 @@ type FileSelectorTheme = {
      * @default chalk.red
      */
     cancelText: (text: string) => string
-    /**
-     * Alias for `emptyText`.
-     * @deprecated Use `emptyText` instead. Will be removed in the next major version.
-     */
-    noFilesFound?: (text: string) => string
     /**
      * The style to use for the empty text.
      * @default chalk.red

--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ const filePath = await fileSelector({
 | `cancelText` | `string` | | The message to display when the user cancels the selection.<br/> **Default**: `Canceled.` |
 | `emptyText` | `string` | | The message that will be displayed when the directory is empty.<br/> **Default**: `Directory is empty.` |
 | `theme` | [See Theming](#theming) | | The theme to use for the file selector. |
-| ~~`canceledLabel`~~ | ~~`string`~~ | | **Deprecated**: Use `cancelText` instead. Will be removed in the next major version. |
 
 ## Theming
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ const filePath = await fileSelector({
 | `cancelText` | `string` | | The message to display when the user cancels the selection.<br/> **Default**: `Canceled.` |
 | `emptyText` | `string` | | The message that will be displayed when the directory is empty.<br/> **Default**: `Directory is empty.` |
 | `theme` | [See Theming](#theming) | | The theme to use for the file selector. |
-| ~~`path`~~ | ~~`string`~~ | | **Deprecated**: Use `basePath` instead. Will be removed in the next major version. |
 | ~~`canceledLabel`~~ | ~~`string`~~ | | **Deprecated**: Use `cancelText` instead. Will be removed in the next major version. |
 
 ## Theming

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,9 +53,9 @@ export default createPrompt<string, FileSelectorConfig>((config, done) => {
     hideNonMatch = false,
     disabledLabel = ' (not allowed)',
     allowCancel = false,
+    cancelText = 'Canceled.',
     emptyText = 'Directory is empty.'
   } = config
-  const cancelText = config.cancelText || config.canceledLabel || 'Canceled.'
 
   const [status, setStatus] = useState('pending')
   const theme = makeTheme<FileSelectorTheme>(fileSelectorTheme, config.theme)

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,7 +62,7 @@ export default createPrompt<string, FileSelectorConfig>((config, done) => {
   const prefix = usePrefix({ theme })
 
   const [currentDir, setCurrentDir] = useState(
-    path.resolve(process.cwd(), config.basePath || config.path || '.')
+    path.resolve(process.cwd(), config.basePath || '.')
   )
 
   const items = useMemo(() => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,15 +52,10 @@ export default createPrompt<string, FileSelectorConfig>((config, done) => {
     pageSize = 10,
     hideNonMatch = false,
     disabledLabel = ' (not allowed)',
-    allowCancel = false
+    allowCancel = false,
+    emptyText = 'Directory is empty.'
   } = config
   const cancelText = config.cancelText || config.canceledLabel || 'Canceled.'
-  const emptyText =
-    config.emptyText || config.noFilesFound || 'Directory is empty.'
-
-  if (config.theme?.style?.noFilesFound) {
-    config.theme.style.emptyText ??= config.theme.style.noFilesFound
-  }
 
   const [status, setStatus] = useState('pending')
   const theme = makeTheme<FileSelectorTheme>(fileSelectorTheme, config.theme)

--- a/src/types.ts
+++ b/src/types.ts
@@ -113,11 +113,6 @@ export type FileSelectorConfig = {
    */
   allowCancel?: boolean
   /**
-   * Alias for `cancelText`.
-   * @deprecated Use `cancelText` instead. Will be removed in the next major version.
-   */
-  canceledLabel?: string
-  /**
    * The message to display when the user cancels the selection.
    * @default 'Canceled.'
    */

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,11 +82,6 @@ export type Item = {
 export type FileSelectorConfig = {
   message: string
   /**
-   * Alias for `basePath`.
-   * @deprecated Use `basePath` instead. Will be removed in the next major version.
-   */
-  path?: string
-  /**
    * The path to the directory where it will be started.
    * @default process.cwd()
    */

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,11 +26,6 @@ export type FileSelectorTheme = {
      */
     cancelText: (text: string) => string
     /**
-     * Alias for `emptyText`.
-     * @deprecated Use `emptyText` instead. Will be removed in the next major version.
-     */
-    noFilesFound?: (text: string) => string
-    /**
      * The style to use for the empty text.
      * @default chalk.red
      */
@@ -132,11 +127,6 @@ export type FileSelectorConfig = {
    * @default 'Canceled.'
    */
   cancelText?: string
-  /**
-   * Alias for `emptyText`.
-   * @deprecated Use `emptyText` instead. Will be removed in the next major version.
-   */
-  noFilesFound?: string
   /**
    * The message that will be displayed when the directory is empty.
    * @default 'Directory is empty.'


### PR DESCRIPTION
### Options removed:

* `noFilesFound` and its equivalent theme option.
* `path`
* `canceledLabel`

> [!NOTE]
> There was a typo both in the `README.md` and in the comments in the `types.ts` file in which it said that these deprecated options would be removed in the next major version, but in reality they will be removed in version 0.5.0 as stated in the changelog of the latest version ([0.4.0](https://github.com/br14n-sol/inquirer-file-selector/releases/tag/v0.4.0)).