### PR TITLE
Adds the possibility to select directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ const filePath = await fileSelector({
 |--------|------|----------|-------------|
 | `message` | `string` | ✔ | The message to display in the prompt. |
 | `basePath` | `string` | | The path to the directory where it will be started.<br/> **Default**: `process.cwd()` |
+| `type` | `'file'︱'directory'︱'file+directory'` | | The type of elements that are valid selection options.<br/> **Default**: `'file'` |
 | `pageSize` | `number` | | The maximum number of items to display in the list.<br/> **Default**: `10` |
 | `loop` | `boolean` | | If `true`, the list will loop from the last item to the first item and vice versa.<br/> **Default**: `false` |
 | `filter` | `(file: FileStats) => boolean` | | A function to filter files and directories.<br/> If not provided, all files and directories will be included by default. |
@@ -81,7 +82,7 @@ type FileSelectorTheme = {
 ```
 
 > [!NOTE]
-> To see the default theme used by the prompt, look at the [fileSelectorTheme](src/index.ts#L29) constant and the [FileSelectorTheme](src/types.ts#L5) type.
+> To see the default theme used by the prompt, look at the [fileSelectorTheme](src/index.ts#L30) constant and the [FileSelectorTheme](src/types.ts#L5) type.
 
 ## Examples
 

--- a/examples/type-selection.js
+++ b/examples/type-selection.js
@@ -1,0 +1,36 @@
+import select, { Separator } from '@inquirer/select';
+import fileSelector from '../dist/index.js';
+
+async function promptForPathSelection() {
+  let selectedOption = await select({
+    message: 'What type of selection do you want to try?',
+    choices: [
+      { name: 'file (default)', value: 'file' },
+      { name: 'directory', value: 'directory' },
+      { name: 'file+directory', value: 'file+directory' },
+      new Separator(),
+      { name: "Exit", value: 'exit' },
+    ],
+  });
+
+  if (selectedOption !== 'exit') {
+    selectedOption = await fileSelector({
+      message: `Select a path:`,
+      type: selectedOption,
+      allowCancel: true,
+    });
+  }
+
+  if (selectedOption === 'canceled') {
+    return promptForPathSelection();
+  }
+
+  return selectedOption;
+}
+
+(async () => {
+  let chosenPath = await promptForPathSelection();
+  while (chosenPath !== 'exit') {
+    chosenPath = await promptForPathSelection();
+  }
+})();

--- a/src/types.ts
+++ b/src/types.ts
@@ -106,6 +106,11 @@ export type FileSelectorConfig = {
    */
   basePath?: string
   /**
+   * The type of elements that are valid selection options.
+   * @default 'file'
+   */
+  type?: 'file' | 'directory' | 'file+directory'
+  /**
    * The maximum number of items to display in the list.
    * @default 10
    */


### PR DESCRIPTION
Closes #18
Replaces #19, #20 [^1]

### A new option is added:

```ts
type?: 'file' | 'directory' | 'file+directory' // by default: 'file'
```

* If `type` is `'file'`, you can only select files.
* If `type` is `'directory'`, you can only select directories.
* If `type` is `'file+directory'`, you can select both files and directories.

![Animation](https://github.com/user-attachments/assets/ec05c854-8970-4929-a280-dc0b89355eca)

### Other changes:

* From now on, the `backspace` key will be used to navigate within directories.

----

### Questions:

* If only directories are expected to be selected, should the files be hidden? [^3]
* If only files are expected to be selected, should the directories be hidden? [^3]
* ~If the directories are hidden, what would navigation be like?~ [^2]
  ~If there are no directories to enter, you could only go backwards in the directory tree, but not forwards.~

[^1]: Thanks to @wenshuishi for suggesting this and making the first implementation.
[^2]: With the introduction of the ability to filter both files and directories in pr #27, the blocking of navigation will not be a priority for the time being.
[^3]: These questions will be addressed in the future.