### PR TITLE
Replace `match` option with `filter`

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,15 @@ const filePath = await fileSelector({
 | `message` | `string` | ✔ | The message to display in the prompt. |
 | `basePath` | `string` | | The path to the directory where it will be started.<br/> **Default**: `process.cwd()` |
 | `pageSize` | `number` | | The maximum number of items to display in the list.<br/> **Default**: `10` |
-| `match` | `(file: Item) => boolean` | | A function to filter the files.<br/> If not provided, all files will be included. |
-| `hideNonMatch` | `boolean` | | If true, the list will be filtered to show only files that match the `match` function.<br/> **Default**: `false` |
+| `filter` | `(file: FileStats) => boolean` | | A function to filter files and directories.<br/> If not provided, all files and directories will be included by default. |
+| `showExcluded` | `boolean` | | If `true`, the list will include files and directories that are excluded by the `filter` function.<br/> **Default**: `false` |
 | `disabledLabel` | `string` | | The label to display when a file is disabled.<br/> **Default**: ` (not allowed)` |
 | `allowCancel` | `boolean` | | If true, the prompt will allow the user to cancel the selection.<br/> **Default**: `false` |
 | `cancelText` | `string` | | The message to display when the user cancels the selection.<br/> **Default**: `Canceled.` |
 | `emptyText` | `string` | | The message that will be displayed when the directory is empty.<br/> **Default**: `Directory is empty.` |
 | `theme` | [See Theming](#theming) | | The theme to use for the file selector. |
+| ~~`match`~~ | ~~`(file: FileStats) => boolean`~~ | | **Deprecated**: Use `filter` instead. |
+| ~~`hideNonMatch`~~ | ~~`boolean`~~ | | **Deprecated**: Use `showExcluded` instead. |
 
 ## Theming
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+import type { Stats } from 'node:fs'
 import type { Theme } from '@inquirer/core'
 import type { PartialDeep } from '@inquirer/type'
 
@@ -58,25 +59,21 @@ export type FileSelectorTheme = {
   }
 }
 
-export type Item = {
+export type FileStats = Stats & {
   /**
-   * The name of the item.
+   * The name of the file or directory.
    */
   name: string
   /**
-   * The path to the item.
+   * The path to the file or directory.
    */
   path: string
   /**
-   * If the item is a directory.
-   */
-  isDir: boolean
-  /**
-   * If the item is disabled, it will be displayed in the list with the `disabledLabel` property.
+   * If the file or directory is disabled, it will be displayed in the list with the `disabledLabel` property.
    *
-   * Set to `true` if the `match` function returns `false`.
+   * Set to `true` if the `filter` function returns `false`.
    */
-  isDisabled?: boolean
+  isDisabled: boolean
 }
 
 export type FileSelectorConfig = {
@@ -92,14 +89,27 @@ export type FileSelectorConfig = {
    */
   pageSize?: number
   /**
+   * A function to filter files and directories. It returns `true` to include the file or directory in the list,
+   * and `false` to exclude it.
+   *
+   * If not provided, all files and directories will be included by default.
+   */
+  filter?: (file: FileStats) => boolean
+  /**
    * The function to use to filter the files. Returns `true` to include the file in the list.
    *
    * If not provided, all files will be included.
+   * @deprecated Use `filter` instead. This option will be removed in the 0.6.0 release.
    */
-  match?: (file: Item) => boolean
+  match?: (file: FileStats) => boolean
   /**
-   * If true, the list will be filtered to show only files that match the `match` function.
+   * If `true`, the list will include files and directories that are excluded by the `filter` function.
    * @default false
+   */
+  showExcluded?: boolean
+  /**
+   * If `false`, the list will include files and directories that are excluded by the `match` function.
+   * @deprecated Use `showExcluded` instead. This option will be removed in the 0.6.0 release.
    */
   hideNonMatch?: boolean
   /**


### PR DESCRIPTION
### Deprecate:

* Options `match` and `hideNonMatch` to be removed entirely in the 0.6.0 version.

### Added:

* Option `filter` to replace `match` option.
  - Apart from the name and path of the file or directory, the properties and methods provided by [`fs.Stats`](https://nodejs.org/docs/latest-v18.x/api/fs.html#class-fsstats) are now also included.

> [!WARNING]
> Unlike the `match` option, `filter` allows you to filter directories as well, so it should be used with caution as it may break the navigation, preventing you from moving forward in the directory tree.

* Option `showExcluded` to replace `hideNonMatch` option.

> [!NOTE]
> As its name indicates `showExcluded` works the other way around than `hideNonMatch`.