### PR TITLE
Add support for changes introduced in @inquirer/core 9.2.0

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import path from 'node:path'
 import {
+  type Status as InquirerStatus,
   createPrompt,
   isBackspaceKey,
   isDownKey,
@@ -15,7 +16,7 @@ import {
 import figures from '@inquirer/figures'
 import chalk from 'chalk'
 
-import type { FileSelectorConfig, FileSelectorTheme } from './types.js'
+import type { FileSelectorConfig, FileSelectorTheme, Status } from './types.js'
 import {
   CURSOR_HIDE,
   ensureTrailingSlash,
@@ -56,7 +57,7 @@ export default createPrompt<string, FileSelectorConfig>((config, done) => {
     emptyText = 'Directory is empty.'
   } = config
 
-  const [status, setStatus] = useState('pending')
+  const [status, setStatus] = useState<Status>('idle')
   const theme = makeTheme<FileSelectorTheme>(fileSelectorTheme, config.theme)
   const prefix = usePrefix({ theme })
 
@@ -71,11 +72,12 @@ export default createPrompt<string, FileSelectorConfig>((config, done) => {
       if (config.filter) {
         file.isDisabled = !filterCheck(file, config.filter)
       } else {
-        file.isDisabled = !file.isDirectory() && !filterCheck(file, config.match)
+        file.isDisabled =
+          !file.isDirectory() && !filterCheck(file, config.match)
       }
     }
 
-    const showExcluded = config.showExcluded ?? (config.hideNonMatch === false)
+    const showExcluded = config.showExcluded ?? config.hideNonMatch === false
     return sortFiles(files, showExcluded)
   }, [currentDir])
 
@@ -153,7 +155,7 @@ export default createPrompt<string, FileSelectorConfig>((config, done) => {
     loop: false
   })
 
-  const message = theme.style.message(config.message)
+  const message = theme.style.message(config.message, status as InquirerStatus) // TODO: remove this cast when resolved: https://github.com/SBoudrias/Inquirer.js/issues/1582
 
   if (status === 'canceled') {
     return `${prefix} ${message} ${theme.style.cancelText(cancelText)}`

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,7 @@ const fileSelectorTheme: FileSelectorTheme = {
     directory: (text: string) => chalk.yellow(text),
     file: (text: string) => chalk.white(text),
     currentDir: (text: string) => chalk.magenta(text),
+    message: (text: string, _status: Status) => chalk.bold(text),
     help: (text: string) => chalk.white(text),
     key: (text: string) => chalk.cyan(text)
   }
@@ -163,7 +164,7 @@ export default createPrompt<string, FileSelectorConfig>((config, done) => {
     loop: false
   })
 
-  const message = theme.style.message(config.message, status as InquirerStatus) // TODO: remove this cast when resolved: https://github.com/SBoudrias/Inquirer.js/issues/1582
+  const message = theme.style.message(config.message, status)
 
   if (status === 'canceled') {
     return `${prefix} ${message} ${theme.style.cancelText(cancelText)}`

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,11 @@ import {
 } from './utils.js'
 
 const fileSelectorTheme: FileSelectorTheme = {
+  prefix: {
+    idle: chalk.cyan('?'),
+    done: chalk.green(figures.tick),
+    canceled: chalk.red(figures.cross)
+  },
   icon: {
     linePrefix: (isLast: boolean) => {
       return isLast
@@ -59,7 +64,10 @@ export default createPrompt<string, FileSelectorConfig>((config, done) => {
 
   const [status, setStatus] = useState<Status>('idle')
   const theme = makeTheme<FileSelectorTheme>(fileSelectorTheme, config.theme)
-  const prefix = usePrefix({ theme })
+  const prefix = usePrefix({
+    status: status as InquirerStatus, // TODO: remove this cast when resolved: https://github.com/SBoudrias/Inquirer.js/issues/1582
+    theme
+  })
 
   const [currentDir, setCurrentDir] = useState(
     path.resolve(process.cwd(), config.basePath || '.')

--- a/src/types.ts
+++ b/src/types.ts
@@ -141,3 +141,9 @@ export type FileSelectorConfig = {
    */
   theme?: PartialDeep<Theme<FileSelectorTheme>>
 }
+
+/**
+ * Internal types
+ */
+
+export type Status = 'idle' | 'done' | 'canceled'

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,6 +64,11 @@ export type FileSelectorTheme = {
      */
     currentDir: (text: string) => string
     /**
+     * The style to use for the message.
+     * @default chalk.bold
+     */
+    message: (text: string, status: Status) => string
+    /**
      * The style to use for the key bindings help.
      * @default chalk.white
      */

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,23 @@ import type { Theme } from '@inquirer/core'
 import type { PartialDeep } from '@inquirer/type'
 
 export type FileSelectorTheme = {
+  prefix: {
+    /**
+     * The prefix to use for the idle status.
+     * @default chalk.cyan('?')
+     */
+    idle: string
+    /**
+     * The prefix to use for the done status.
+     * @default chalk.green(figures.tick)
+     */
+    done: string
+    /**
+     * The prefix to use for the canceled status.
+     * @default chalk.red(figures.cross)
+     */
+    canceled: string
+  }
   icon: {
     /**
      * The prefix to use for the line.


### PR DESCRIPTION
- Added support for custom prefix based on the status of the prompt
  - `idle`: ![image](https://github.com/user-attachments/assets/7c264ede-4abf-4bd3-84b4-529da8339d96)
  - `done`: ![image](https://github.com/user-attachments/assets/4c7638dd-2994-4e4c-a460-13918538d276)
  - `canceled`: ![image](https://github.com/user-attachments/assets/d66c8870-6dbd-45bc-80e2-e999524e468d)

- Now `theme.message` will have a second parameter called `status` with which you can change the color of the message depending on the status of the prompt.
> [!NOTE]
> By default the value of `theme.message` will remain `chalk.bold` regardless of the state of the prompt.