### PR TITLE
Feature: Add Current Directory Selection Option

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -74,7 +74,7 @@ export default createPrompt<string, FileSelectorConfig>((config, done) => {
   )
 
   const items = useMemo(() => {
-    const files = getDirFiles(currentDir)
+    const files = getDirFiles(currentDir, type)
 
     for (const file of files) {
       file.isDisabled = config.filter ? !config.filter(file) : false

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -43,8 +43,12 @@ export function getMaxLength(arr: string[]): number {
 /**
  * Get files of a directory
  */
-export function getDirFiles(dir: string): FileStats[] {
-  return fs.readdirSync(dir).map(filename => {
+export function getDirFiles(dir: string, type: string): FileStats[] {
+  const files: string[] = fs.readdirSync(dir)
+  if (type === 'directory' || type === 'file+directory') {
+    files.unshift('.')
+  }
+  return files.map(filename => {
     const filepath = path.join(dir, filename)
     const fileStat = fs.statSync(filepath)
 


### PR DESCRIPTION
This enhancement introduces the ability to select the current directory (.) when browsing directories in the CLI file selector, improving user experience and navigation efficiency.
Key Improvements:

Provides a straightforward method to select the default path when already in the target directory
Eliminates the previous workaround of navigating up a directory to select the current location
Enables immediate directory validation by allowing selection while viewing directory contents

The implementation adds the ./ option to the directory listing, giving users a more intuitive and direct way to choose their desired path.