### PR TITLE
Make both files and directories selectable by default

### DIFF
--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -1,3 +1,1 @@
 export type Status = 'idle' | 'done' | 'canceled'
-
-export type SelectionType = 'file' | 'directory' | 'file+directory'

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1,7 +1,6 @@
 import type { Theme } from '@inquirer/core'
 import type { PartialDeep } from '@inquirer/type'
 
-import type { SelectionType } from '#types/common'
 import type { FileStats } from '#types/file'
 import type { CustomTheme } from '#types/theme'
 
@@ -14,9 +13,10 @@ export interface FileSelectorConfig {
   basePath?: string
   /**
    * The type of elements that are valid selection options.
-   * @default 'file'
+   *
+   * If not provided, all files and directories are valid selection options.
    */
-  type?: SelectionType
+  type?: 'file' | 'directory'
   /**
    * The maximum number of items to display in the list.
    * @default 10

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -1,7 +1,6 @@
 import fs from 'node:fs'
 import path from 'node:path'
 
-import type { SelectionType } from '#types/common'
 import type { FileStats } from '#types/file'
 
 /**
@@ -14,14 +13,8 @@ export function ensureTrailingSlash(dir: string): string {
 /**
  * Get files of a directory
  */
-export function getDirFiles(dir: string, type: SelectionType): FileStats[] {
-  const files: string[] = fs.readdirSync(dir)
-
-  if (type === 'directory' || type === 'file+directory') {
-    files.unshift('.')
-  }
-
-  return files.map(filename => {
+export function getDirFiles(dir: string): FileStats[] {
+  return fs.readdirSync(dir).map(filename => {
     const filepath = path.join(dir, filename)
     const fileStat = fs.statSync(filepath)
 


### PR DESCRIPTION
- Removed `file+directory` from `config.type`.
- Adjusted logic to assume all files and directories are valid options by default.
- Refactored `getDirFiles` to remove dependency on `config.type`.