### PR TITLE
Fix incorrect symbol in file tree when `loop` is `true`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -127,7 +127,7 @@ export const fileSelector = createPrompt<string | null, FileSelectorConfig>(
       items,
       active,
       renderItem: ({ item, index, isActive }) =>
-        theme.renderItem(item, { items, index, isActive }),
+        theme.renderItem(item, { items, index, isActive, loop }),
       pageSize,
       loop
     })

--- a/src/themes/base.ts
+++ b/src/themes/base.ts
@@ -33,9 +33,10 @@ const theme: CustomTheme = {
   },
   renderItem(item: FileStats, context: RenderContext) {
     const isLast = context.index === context.items.length - 1
-    const linePrefix = isLast
-      ? this.hierarchySymbols.leaf
-      : this.hierarchySymbols.branch
+    const linePrefix =
+      isLast && !context.loop
+        ? this.hierarchySymbols.leaf
+        : this.hierarchySymbols.branch
     const isDirectory = item.isDirectory()
     const line = isDirectory
       ? `${linePrefix} ${ensurePathSeparator(item.name)}`

--- a/src/types/theme.ts
+++ b/src/types/theme.ts
@@ -14,6 +14,10 @@ export type RenderContext = {
    * Whether the item is currently active.
    */
   isActive: boolean
+  /**
+   * List is displayed in loop mode.
+   */
+  loop: boolean
 }
 
 export interface CustomTheme {


### PR DESCRIPTION
Closes #62 

| before | now |
| - | - |
| ![image](https://github.com/user-attachments/assets/71ad76f3-52fe-46c7-8dee-bef856055710) | ![image](https://github.com/user-attachments/assets/8846c81c-9a0c-4f2b-bbb6-aac14288c3d7) |