### PR TITLE
Migrate Rollup config from Ts to js

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint:fix": "biome check --write",
     "clean": "rimraf dist",
     "prebuild": "npm run clean && npm run lint",
-    "build": "rollup -c --configPlugin typescript"
+    "build": "rollup -c"
   },
   "nano-staged": {
     "*.{ts,json}": "biome check --write --no-errors-on-unmatched"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,15 +1,12 @@
 import terser from '@rollup/plugin-terser'
 import typescript from '@rollup/plugin-typescript'
-import type { RollupOptions } from 'rollup'
 import { dts } from 'rollup-plugin-dts'
 import nodeExternals from 'rollup-plugin-node-externals'
 import tsConfigPaths from 'rollup-plugin-tsconfig-paths'
-
 import pkg from './package.json' with { type: 'json' }
 
 const { main, types } = pkg
-
-const bundle = (options: RollupOptions): RollupOptions => ({
+const bundle = options => ({
   ...options,
   input: 'src/index.ts'
 })


### PR DESCRIPTION
This change prevents a deprecation warning in Node.js 20:

```bash
(node:6320) V8: file:///home/brian/projects/inquirer-file-selector/rollup.config-1742924495969.mjs:6 'assert' is deprecated in import statements and support will be removed in a future version; use 'with' instead
```

Related rollup/plugins#1762