### PR TITLE
fix(theme): improve visibility in light color schemes

### DIFF
--- a/src/theme.ts
+++ b/src/theme.ts
@@ -12,15 +12,15 @@ export const baseTheme: PromptTheme = {
   },
   style: {
     disabled: (linePrefix: string, text: string) =>
-      chalk.dim(`${linePrefix} ${chalk.strikethrough(text)}`),
+      chalk.gray(`${linePrefix} ${chalk.strikethrough(text)}`),
     active: (text: string) => chalk.cyan(text),
     cancelText: (text: string) => chalk.red(text),
     emptyText: (text: string) => chalk.red(text),
-    directory: (text: string) => chalk.yellow(text),
-    file: (text: string) => chalk.white(text),
-    currentDir: (text: string) => chalk.magenta(text),
+    directory: (text: string) => chalk.yellowBright(text),
+    file: (text: string) => text,
+    currentDir: (text: string) => chalk.magentaBright(text),
     message: (text: string, _status: StatusType) => chalk.bold(text),
-    help: (text: string) => chalk.italic.dim(text)
+    help: (text: string) => chalk.italic.gray(text)
   },
   hierarchySymbols: {
     branch: figures.lineUpDownRight + figures.line,

--- a/src/types/theme.ts
+++ b/src/types/theme.ts
@@ -35,7 +35,7 @@ export interface PromptTheme {
   style: {
     /**
      * Defines the style for disabled items.
-     * @default chalk.strikethrough.dim
+     * @default chalk.strikethrough.gray
      */
     disabled: (linePrefix: string, text: string) => string
     /**
@@ -55,17 +55,17 @@ export interface PromptTheme {
     emptyText: (text: string) => string
     /**
      * Defines the style for items of type `'directory'`.
-     * @default chalk.yellow
+     * @default chalk.yellowBright
      */
     directory: (text: string) => string
     /**
      * Defines the style for items of type `'file'`.
-     * @default chalk.white
+     * @default No style applied
      */
     file: (text: string) => string
     /**
      * Defines the style for the current directory header.
-     * @default chalk.magenta
+     * @default chalk.magentaBright
      */
     currentDir: (text: string) => string
     /**
@@ -75,7 +75,7 @@ export interface PromptTheme {
     message: (text: string, status: StatusType) => string
     /**
      * Defines the style for help messages.
-     * @default chalk.italic.dim
+     * @default chalk.italic.gray
      */
     help: (text: string) => string
   }


### PR DESCRIPTION
Closes #71 

<table>
<thead>
<tr>
<th colspan="2">Before</th>
</tr>
<tr>
<th>Dark</th><th>Light</th>
</tr>
</thead>
<tbody>
<tr>
<td>

![Capture from 2025-03-31 16-54-13](https://github.com/user-attachments/assets/51b122b3-af3e-4b91-a914-83af50449817)

</td>
<td>

![Capture from 2025-03-31 16-54-29](https://github.com/user-attachments/assets/daa5b8bf-208d-4a3e-9ce4-fae0d5738fd4)

</td>
</tr>
</tbody>
</table>

<table>
<thead>
<tr>
<th colspan="2">This pr</th>
</tr>
<tr>
<th>Dark</th><th>Light</th>
</tr>
</thead>
<tbody>
<tr>
<td>

![Capture from 2025-03-31 16-52-59](https://github.com/user-attachments/assets/6973147b-7cde-42ab-a52f-9b39fd072e22)

</td>
<td>

![Capture from 2025-03-31 16-52-32](https://github.com/user-attachments/assets/289c6aa5-acca-4a72-8b18-c8ef5dd14a55)

</td>
</tr>
</tbody>
</table>