### PR TITLE
fix(deps): @inquirer/type was incorrectly listed as devDependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,13 +11,13 @@
       "dependencies": {
         "@inquirer/core": "^10.1.9",
         "@inquirer/figures": "^1.0.11",
+        "@inquirer/type": "^3.0.5",
         "chalk": "^5.4.1"
       },
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
         "@commitlint/cli": "19.8.0",
         "@commitlint/config-conventional": "19.8.0",
-        "@inquirer/type": "3.0.5",
         "@rollup/plugin-terser": "0.4.4",
         "@rollup/plugin-typescript": "12.1.2",
         "husky": "9.1.7",

--- a/package.json
+++ b/package.json
@@ -22,13 +22,13 @@
   "dependencies": {
     "@inquirer/core": "^10.1.9",
     "@inquirer/figures": "^1.0.11",
+    "@inquirer/type": "^3.0.5",
     "chalk": "^5.4.1"
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
     "@commitlint/cli": "19.8.0",
     "@commitlint/config-conventional": "19.8.0",
-    "@inquirer/type": "3.0.5",
     "@rollup/plugin-terser": "0.4.4",
     "@rollup/plugin-typescript": "12.1.2",
     "husky": "9.1.7",


### PR DESCRIPTION
This package is required at runtime because some of its types are exposed in the public type declarations of this package. It has now been moved to dependencies to ensure that it is installed when consumers install this package.