### PR TITLE
feat: return sanitized Item object without internal-only properties

### DIFF
--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,6 +1,6 @@
 import figures from '@inquirer/figures'
 import chalk from 'chalk'
-import type { Item } from '#types/item'
+import type { RawItem } from '#types/item'
 import type { StatusType } from '#types/status'
 import type { PromptTheme, RenderContext } from '#types/theme'
 
@@ -33,7 +33,7 @@ export const baseTheme: PromptTheme = {
       `(Press ${!isCwd ? '<space> to open, ' : ''}<enter> to select)`,
     file: '(Press <enter> to select)'
   },
-  renderItem(item: Item, context: RenderContext) {
+  renderItem(item: RawItem, context: RenderContext) {
     const isLast = context.index === context.items.length - 1
     const linePrefix =
       isLast && !context.loop

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -30,7 +30,7 @@ export interface PromptConfig {
    * Filters items in the list.
    * @param item - Item to evaluate.
    */
-  filter?: (item: Item) => boolean
+  filter?: (item: Readonly<Item>) => boolean
   /**
    * Indicates if items excluded by `filter` are visible.
    * @default false

--- a/src/types/item.ts
+++ b/src/types/item.ts
@@ -1,6 +1,4 @@
 export type Item = {
-  /** Display name used in the list. */
-  displayName: string
   name: string
   path: string
   /** Size in bytes. */
@@ -9,13 +7,10 @@ export type Item = {
   createdMs: number
   /** Last modification timestamp (milliseconds since POSIX Epoch). */
   lastModifiedMs: number
-  /**
-   * Indicates if the item is disabled.
-   * - `false`: Visible in the list.
-   * - `true`: Hidden unless `showExcluded` is `true`.
-   *
-   * Set to `true` if `config.filter` returns `false`.
-   */
-  isDisabled: boolean
   isDirectory: boolean
+}
+
+export type RawItem = Item & {
+  displayName: string
+  isDisabled: boolean
 }

--- a/src/types/theme.ts
+++ b/src/types/theme.ts
@@ -1,9 +1,9 @@
-import type { Item } from '#types/item'
+import type { RawItem } from '#types/item'
 import type { StatusType } from '#types/status'
 
 export type RenderContext = {
   /** Items to render. */
-  items: Item[]
+  items: RawItem[]
   /** Indicates if the list is displayed in loop mode. */
   loop: boolean
   /** Item index. */
@@ -110,5 +110,5 @@ export interface PromptTheme {
    * @param item - The item to render.
    * @param context - Additional context about the item.
    */
-  renderItem: (item: Item, context: RenderContext) => string
+  renderItem: (item: RawItem, context: RenderContext) => string
 }

--- a/src/utils/item.ts
+++ b/src/utils/item.ts
@@ -1,14 +1,14 @@
 import { readdirSync, statSync } from 'node:fs'
 import { basename, join, sep } from 'node:path'
-import type { Item } from '#types/item'
+import type { Item, RawItem } from '#types/item'
 
-/** Ensures the path ends with a separator (`/` or `\`). */
+/** Appends the system-specific path separator to the end of the path if missing. */
 export function ensurePathSeparator(path: string): string {
   return path.endsWith(sep) ? path : `${path}${sep}`
 }
 
-/** Creates an `Item' object from a file path. */
-export function createItemFromPath(path: string): Item {
+/** Creates a `RawItem` from a given filesystem path. */
+export function createRawItem(path: string): RawItem {
   const stats = statSync(path)
   const name = basename(path)
   const isDirectory = stats.isDirectory()
@@ -26,22 +26,24 @@ export function createItemFromPath(path: string): Item {
   }
 }
 
-/** Get items from a directory. */
-export function getDirItems(path: string): Item[] {
+/** Reads all entries in the directory and returns them as `RawItem[]`. */
+export function readRawItems(path: string): RawItem[] {
   return readdirSync(path).map(fileName => {
     const filePath = join(path, fileName)
-    return createItemFromPath(filePath)
+    return createRawItem(filePath)
   })
 }
 
 /**
- * Sort an array of `Item` objects by the following criteria:
- * 1. Disabled items are placed at the end.
- * 2. Directories are placed before files.
- * 3. Alphabetically if the priorities match.
+ * Sorts the given array of `RawItem`s by the following criteria:
+ * 1. Enabled items before disabled ones.
+ * 2. Directories before files.
+ * 3. Alphabetical order (by name) if priorities match.
+ *
+ * Mutates the original array.
  */
-export function sortItems(items: Item[]): Item[] {
-  return items.sort((a, b) => {
+export function sortRawItems(items: RawItem[]): void {
+  items.sort((a, b) => {
     const aPriority = (a.isDisabled ? 2 : 0) + (a.isDirectory ? -1 : 0)
     const bPriority = (b.isDisabled ? 2 : 0) + (b.isDirectory ? -1 : 0)
 
@@ -51,4 +53,10 @@ export function sortItems(items: Item[]): Item[] {
 
     return a.name.localeCompare(b.name)
   })
+}
+
+/** Removes internal-only properties (`displayName` and `isDisabled`) from a `RawItem`. */
+export function stripInternalProps(raw: RawItem): Item {
+  const { displayName, isDisabled, ...item } = raw
+  return item
 }


### PR DESCRIPTION
| Before | This pr |
| - | - |
| ![image](https://github.com/user-attachments/assets/f9fc5c39-4c8b-45fd-b42d-374834be522a) | ![image](https://github.com/user-attachments/assets/fcb96af1-d5d4-4c2b-8892-98cc0e54aadb) |

Additionally, the signature of `PromptConfig.filter` was modified.
| Before | This pr |
| - | - |
| `filter?: (item: Item) => boolean` | `filter?: (item: Readonly<Item>) => boolean` |