### PR TITLE
fix: crash when type is file and confirming in empty directory

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -166,6 +166,8 @@ export function fileSelector(
         setActive(active - 1)
         setActive(active)
       } else if (action.isConfirm(key)) {
+        if (!activeItem) return
+
         let result = null
 
         if (multiple) {


### PR DESCRIPTION
It's currently possible to confirm inside an empty directory if the type is "file", which causes a crash because the `activeItem` is undefined and we try to access its properties within `isValidItemType`.

<img width="496" height="212" alt="image" src="https://github.com/user-attachments/assets/39e856f1-09d3-4030-8937-d5d34bc5f977" />
<img width="491" height="19" alt="image" src="https://github.com/user-attachments/assets/97308ace-01c8-45c2-b172-9e9098bde558" />


## Repro steps
1. In "file" mode, navigate into an empty directory, which will display the `emptyText` message (by default, "Directory is empty.")
2. Hit "Enter."
3. Crash.

## Changes
This PR changes the behavior to disallow selection in this case. 