### PR TITLE
Release 1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "inquirer-file-selector",
   "author": "Brian Fernandez",
   "description": "Inquirer file selector prompt.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
This version is exactly the same as 1.0.0, which cannot be published because, according to npm, that version was already published 5 years ago, long before this package existed... :face_exhaling: