### PR TITLE
Revert "chore: migrate rollup config from ts to js (#80)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint:fix": "biome check --write",
     "clean": "rimraf dist",
     "prebuild": "pnpm clean && pnpm lint",
-    "build": "rollup -c"
+    "build": "rollup -c --configPlugin typescript"
   },
   "nano-staged": {
     "*.{ts,json}": "biome check --write --no-errors-on-unmatched"

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -1,12 +1,14 @@
 import terser from '@rollup/plugin-terser'
 import typescript from '@rollup/plugin-typescript'
+import type { RollupOptions } from 'rollup'
 import { dts } from 'rollup-plugin-dts'
 import nodeExternals from 'rollup-plugin-node-externals'
 import tsConfigPaths from 'rollup-plugin-tsconfig-paths'
 import pkg from './package.json' with { type: 'json' }
 
 const { main, types } = pkg
-const bundle = options => ({
+
+const bundle = (options: RollupOptions): RollupOptions => ({
   ...options,
   input: 'src/index.ts'
 })


### PR DESCRIPTION
This PR does not resolve the issue in #80; it will be addressed in a subsequent PR.