### PR TITLE
feat: Add ability to prevent user from navigating back a directory

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -56,7 +56,8 @@ export function fileSelector(
       loop = false,
       filter = () => true,
       showExcluded = false,
-      allowCancel = false
+      allowCancel = false,
+      allowBack = () => true
     } = config
 
     const [status, setStatus] = useState<StatusType>(Status.Idle)
@@ -93,8 +94,11 @@ export function fileSelector(
         const cwd = createRawItem(currentDir)
         cwd.displayName = ensurePathSeparator('.')
         cwd.isCwd = cwd.path === currentDir
-
-        rawItems.unshift(cwd)
+        const strippedItem = stripInternalProps(cwd)
+        cwd.isDisabled = !filter(strippedItem)
+        if (showExcluded || !cwd.isDisabled) {
+          rawItems.unshift(cwd)
+        }
       }
 
       // Mark selected items
@@ -136,7 +140,10 @@ export function fileSelector(
 
         setActive(next)
       } else if (action.isBack(key)) {
-        setCurrentDir(path.resolve(currentDir, '..'))
+        const backDir = path.resolve(currentDir, '..')
+        if (!allowBack(backDir)) return
+
+        setCurrentDir(backDir)
         setActive(bounds.first)
       } else if (action.isForward(key)) {
         if (!activeItem.isDirectory) return

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -51,6 +51,11 @@ export interface PromptConfig {
    */
   allowCancel?: boolean
   /**
+   * Indicates if the directory to move back to is allowed.
+   * @param backDir - Directory to move back to
+   */
+  allowBack?: (backDir: string) => boolean
+  /**
    * Keybinds for actions.
    * If omitted, default keybinds are used.
    */


### PR DESCRIPTION
- Added new `allowBack` property which allows/disallows navigating back using a function
- Added ability for the `filter` function to filter the `./` item

This can be used something like this:
```typescript
const directory = await fileSelector({
  message: 'Select directory',
  type: 'directory',
  basePath: project_root,
  allowBack: backDir => backDir.startsWith(project_root)
});
```

Closes #134 